### PR TITLE
Remove unnecessary usage of async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,17 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
-name = "async-recursion"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,40 +29,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bytes"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
 name = "cargo-clean-recursive"
 version = "0.9.2"
 dependencies = [
  "anyhow",
- "async-recursion",
  "clap",
- "futures",
- "tokio",
- "tokio-stream",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -88,100 +55,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
-
-[[package]]
-name = "futures-task"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
-
-[[package]]
-name = "futures-util"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
-dependencies = [
- "autocfg",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
 ]
 
 [[package]]
@@ -200,140 +73,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
-name = "log"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "once_cell"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "syn"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
 
 [[package]]
 name = "textwrap"
@@ -345,56 +88,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
-dependencies = [
- "autocfg",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "once_cell",
- "pin-project-lite",
- "signal-hook-registry",
- "tokio-macros",
- "winapi",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,4 @@ version = "0.9.2"
 
 [dependencies]
 anyhow = "1.0"
-async-recursion = "0.3.2"
 clap = "2.33"
-futures = "0.3.17"
-tokio = {version = "1.10.1", features = ["fs", "macros", "process", "rt", "rt-multi-thread", "sync"]}
-tokio-stream = {version = "0.1.7", features = ["fs"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,12 @@
 use std::env::{args, current_dir};
+use std::fs::read_dir;
 use std::path::{Path, PathBuf};
-
-use async_recursion::async_recursion;
-use futures::stream::{FuturesUnordered, StreamExt};
-use tokio::fs::read_dir;
-use tokio::process::Command;
+use std::process::{self, Child, Command};
 
 use anyhow::{Context, Result};
 use clap::{App, Arg};
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let mut args: Vec<String> = args().collect();
     if args.len() >= 2 && &args[1] == "clean-recursive" {
         args.remove(1);
@@ -60,36 +56,12 @@ async fn main() -> Result<()> {
         current_dir().context("getting current_dir")?
     };
 
-    process_dir(path, depth, delete_mode).await?;
+    let mut children = Vec::new();
 
-    Ok(())
-}
+    process_dir(path, depth, delete_mode, &mut children)?;
 
-#[async_recursion]
-async fn process_dir(path: PathBuf, depth: usize, del_mode: DeleteMode) -> Result<()> {
-    if depth == 0 {
-        return Ok(());
-    }
-
-    detect_and_clean(&path, del_mode)
-        .await
-        .with_context(|| format!("cleaning directory {:?}", path))?;
-
-    let mut rd = read_dir(&path)
-        .await
-        .with_context(|| format!("reading directory {:?}", path.canonicalize()))?;
-
-    let mut proc_dirs = FuturesUnordered::new();
-
-    while let Some(e) = rd.next_entry().await? {
-        if e.file_type().await?.is_dir() {
-            let pd = process_dir(e.path(), depth - 1, del_mode);
-            proc_dirs.push(pd);
-        }
-    }
-
-    while let Some(res) = proc_dirs.next().await {
-        if let Err(e) = res {
+    for mut child in children {
+        if let Err(e) = child.wait() {
             eprintln!("{:#}", e);
         }
     }
@@ -97,41 +69,63 @@ async fn process_dir(path: PathBuf, depth: usize, del_mode: DeleteMode) -> Resul
     Ok(())
 }
 
-async fn detect_and_clean(path: &Path, del_mode: DeleteMode) -> Result<()> {
-    if !path.join("Cargo.toml").exists() {
+fn process_dir(
+    path: PathBuf,
+    depth: usize,
+    del_mode: DeleteMode,
+    children: &mut Vec<Child>,
+) -> Result<()> {
+    if depth == 0 {
         return Ok(());
     }
 
-    let target_dir = path.join("target");
-    if !target_dir.exists() || !target_dir.is_dir() {
+    detect_and_clean(&path, del_mode, children)
+        .with_context(|| format!("cleaning directory {:?}", path))?;
+
+    let rd =
+        read_dir(&path).with_context(|| format!("reading directory {:?}", path.canonicalize()))?;
+
+    for entry in rd {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            process_dir(entry.path(), depth - 1, del_mode, children)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn detect_and_clean(path: &Path, del_mode: DeleteMode, children: &mut Vec<Child>) -> Result<()> {
+    let should_clean = path.join("Cargo.toml").is_file() && path.join("target").is_dir();
+    if !should_clean {
         return Ok(());
     }
 
     eprintln!("Cleaning {:?}", path);
 
     if del_mode.do_all() {
-        Command::new("cargo")
-            .args(&["clean"])
-            .current_dir(path)
-            .output()
-            .await?;
+        children.push(spawn_cargo_clean(path, &[])?);
     }
     if del_mode.do_release() {
-        Command::new("cargo")
-            .args(&["clean", "--release"])
-            .current_dir(path)
-            .output()
-            .await?;
+        children.push(spawn_cargo_clean(path, &["--release"])?);
     }
     if del_mode.do_doc() {
-        Command::new("cargo")
-            .args(&["clean", "--doc"])
-            .current_dir(path)
-            .output()
-            .await?;
+        children.push(spawn_cargo_clean(path, &["--doc"])?);
     }
 
     Ok(())
+}
+
+fn spawn_cargo_clean(current_dir: &Path, args: &[&str]) -> Result<Child> {
+    Command::new("cargo")
+        .arg("clean")
+        .args(args)
+        .current_dir(current_dir)
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::null())
+        .stderr(process::Stdio::null())
+        .spawn()
+        .context("failed to spawn `cargo clean`")
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Async isn't really necessary in this project for the following reasons:

1. Async only gives performance improvements when dealing with network sockets and pipes. When dealing with the filesystem, all I/O is required by the OS to be synchronous anyway so async doesn't help.
2. The old code did not spawn any tasks, so was not making use of Tokio's multi-threaded runtime. It was in fact entirely single-threaded but had a bunch of unnecessary threads hanging around in the background that would just exit at the end having done nothing.
3. Even without async the nature of Rust's `process::Child` API allows as many `cargo clean` instances to run in parallel as you wish: you simply have to spawn a bunch of processes with `.spawn()` and then synchronously `.wait()` on them later. I do this by collecting them into a big `Vec` then waiting for them all to complete at the end.

I did a couple other small refactors to avoid copy-pasting too much code, such as extracting the child spawning logic to a `spawn_cargo_clean` function.