### PR TITLE
Add Printing for the Total Amount of Space Saved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,10 +32,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+
+[[package]]
 name = "cargo-clean-recursive"
 version = "0.9.6"
 dependencies = [
  "anyhow",
+ "bytesize",
  "clap",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ version = "0.9.6"
 
 [dependencies]
 anyhow = "1.0.57"
+bytesize = "1.3.0"
 clap = { version = "3.1.12", features = ["derive"] }


### PR DESCRIPTION
I created a somewhat hacky solution that just parses the `cargo clean` output. This would be subject to breaking if the `cargo clean` output text changes, in which case it will not panic, but will just underestimate the amount of space that is saved.

Addresses #8 