### PR TITLE
fix: workspace members affect --dry-run estimation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ const DEFAULT_SKIP_DIR_NAMES: [&str; 3] = [".git", ".rustup", ".cargo"];
 
 fn main() -> Result<()> {
     let mut args = args();
-    if let Some("clean-recursive") = std::env::args().skip(1).next().as_deref() {
+    if let Some("clean-recursive") = std::env::args().nth(1).as_deref() {
         args.next();
     }
     let args = Args::parse_from(args);
@@ -232,7 +232,9 @@ fn detect_and_clean(
     executions: &mut Vec<CargoCleanExecution>,
 ) -> Result<()> {
     let is_cargo_dir = path.join("Cargo.toml").is_file();
-    if !is_cargo_dir {
+    // Don't attempt to clean workspace members, affects --dry-run estimation.
+    let is_standalone = path.join("Cargo.lock").is_file();
+    if !(is_cargo_dir && is_standalone) {
         return Ok(());
     }
 


### PR DESCRIPTION
Currently, `cargo clean-recursive --dry-run` spawns a `cargo clean` child in each crate subdirectory of a project folder. In reality, cleaning a workspace member without a specified `--package` is no different from cleaning its workspace root.
In `--dry-run`, this makes any workspace estimate significantly more space usage.

[The Cargo Book](https://doc.rust-lang.org/cargo/reference/workspaces.html) defines a workspace as a directory with a `[workspace]` section in its `Cargo.toml`, while workspace members don't have their own `Cargo.lock`.

We could opt out of cleaning any children of a workspace root (at least for accurate `--dry-run`), however, we also have to address the `exclude` field (subdirectories can be standalone crates).

One solution is to check for both `Cargo.toml` and `Cargo.lock`, since standalone crates with no `Cargo.lock` were arguably not built yet.
There is now a possibility of a false negative if a crate is missing its lock file for some reason.

With all that said, this PR should resolve #14, although more testing is needed.